### PR TITLE
feat(island): attached/detached position modes with long-press drag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- 灵动岛支持"吸附菜单栏"和"自由拖拽"两种位置模式，可通过菜单栏切换，位置偏好跨启动持久化 (#7)
 - 测试框架：添加 `LyrislandTests` 测试 target（Swift Testing），包含 LRCParser、TrackMatcher、SyncedLyrics 的单元测试（共 19 个） (#11)
 - 统一日志系统：支持 debug/info/warning/error 级别，按日轮转写入 `~/Library/Logs/Lyrisland/`，启动时自动清理 30 天前日志，同时转发至 os.Logger（Console.app 可查看）(#9)
 - 灵动岛显示专辑封面：Compact 状态显示小缩略图，Expanded 状态左侧显示中等封面，Full 状态左侧显示大封面配合歌词滚动 (#8)

--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -75,6 +75,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var dualLineMenuItem: NSMenuItem?
     private var showArtworkMenuItem: NSMenuItem?
     private var offsetMenuItem: NSMenuItem?
+    private var positionModeMenuItem: NSMenuItem?
 
     private func setupMenuBar() {
         statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.squareLength)
@@ -109,6 +110,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         )
         showArtworkMenuItem?.state = appState.showArtwork ? .on : .off
         menu.addItem(showArtworkMenuItem!)
+
+        let isAttached = UserDefaults.standard.islandPositionMode == .attached
+        positionModeMenuItem = NSMenuItem(
+            title: isAttached ? String(localized: "menu.position.detach") : String(localized: "menu.position.attach"),
+            action: #selector(togglePositionMode),
+            keyEquivalent: "p"
+        )
+        positionModeMenuItem?.target = self
+        menu.addItem(positionModeMenuItem!)
 
         menu.addItem(.separator())
 
@@ -159,6 +169,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         )
         islandPanel = DynamicIslandPanel(contentView: contentView)
         islandPanel?.orderFrontRegardless()
+
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(positionModeDidChange),
+            name: .islandPositionModeChanged,
+            object: nil
+        )
+    }
+
+    @objc private func positionModeDidChange() {
+        updatePositionModeMenuItem()
     }
 
     // MARK: - Playback Monitoring
@@ -237,6 +258,20 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     @objc private func toggleArtwork() {
         appState.showArtwork.toggle()
         showArtworkMenuItem?.state = appState.showArtwork ? .on : .off
+    }
+
+    @objc private func togglePositionMode() {
+        guard let panel = islandPanel else { return }
+        let newMode: IslandPositionMode = panel.positionMode == .attached ? .detached : .attached
+        panel.setPositionMode(newMode)
+        updatePositionModeMenuItem()
+    }
+
+    private func updatePositionModeMenuItem() {
+        guard let panel = islandPanel else { return }
+        positionModeMenuItem?.title = panel.positionMode == .attached
+            ? String(localized: "menu.position.detach")
+            : String(localized: "menu.position.attach")
     }
 
     @objc private func toggleIsland() {

--- a/Sources/Resources/Localizable.xcstrings
+++ b/Sources/Resources/Localizable.xcstrings
@@ -230,6 +230,18 @@
         "zh-Hans": { "stringUnit": { "state": "translated", "value": "退出" } }
       }
     },
+    "menu.position.attach": {
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Attach to Menu Bar" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "吸附到菜单栏" } }
+      }
+    },
+    "menu.position.detach": {
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Detach from Menu Bar" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "脱离菜单栏" } }
+      }
+    },
     "lyrics.loading": {
       "localizations": {
         "en": { "stringUnit": { "state": "translated", "value": "Loading lyrics…" } },

--- a/Sources/Views/AttachedIslandShape.swift
+++ b/Sources/Views/AttachedIslandShape.swift
@@ -1,0 +1,68 @@
+import SwiftUI
+
+/// Shape for the attached island: inverse (concave) corners at the top,
+/// regular rounded corners at the bottom.
+struct AttachedIslandShape: Shape {
+    var bottomRadius: CGFloat
+    var inverseRadius: CGFloat
+
+    func path(in rect: CGRect) -> Path {
+        let w = rect.width
+        let h = rect.height
+        let ir = inverseRadius
+        let br = bottomRadius
+
+        var path = Path()
+
+        // Top-left corner
+        path.move(to: CGPoint(x: 0, y: 0))
+
+        // Left inverse corner: concave arc from (0, 0) to (ir, ir)
+        path.addArc(
+            center: CGPoint(x: 0, y: ir),
+            radius: ir,
+            startAngle: .degrees(270),
+            endAngle: .degrees(0),
+            clockwise: false
+        )
+
+        // Left body edge down to bottom-left corner
+        path.addLine(to: CGPoint(x: ir, y: h - br))
+
+        // Bottom-left corner
+        path.addArc(
+            center: CGPoint(x: ir + br, y: h - br),
+            radius: br,
+            startAngle: .degrees(180),
+            endAngle: .degrees(90),
+            clockwise: true
+        )
+
+        // Bottom edge
+        path.addLine(to: CGPoint(x: w - ir - br, y: h))
+
+        // Bottom-right corner
+        path.addArc(
+            center: CGPoint(x: w - ir - br, y: h - br),
+            radius: br,
+            startAngle: .degrees(90),
+            endAngle: .degrees(0),
+            clockwise: true
+        )
+
+        // Right body edge up to right inverse corner
+        path.addLine(to: CGPoint(x: w - ir, y: ir))
+
+        // Right inverse corner: concave arc from (w-ir, ir) to (w, 0)
+        path.addArc(
+            center: CGPoint(x: w, y: ir),
+            radius: ir,
+            startAngle: .degrees(180),
+            endAngle: .degrees(270),
+            clockwise: false
+        )
+
+        path.closeSubpath()
+        return path
+    }
+}

--- a/Sources/Views/IslandContentView.swift
+++ b/Sources/Views/IslandContentView.swift
@@ -6,33 +6,63 @@ struct IslandContentView: View {
     @ObservedObject var lyricsManager: LyricsManager
     @ObservedObject var appState: AppState
     @State private var islandState: IslandState = .compact
+    @State private var isAttached: Bool = UserDefaults.standard.islandPositionMode == .attached
 
     var body: some View {
-        ZStack {
-            // Background capsule
-            RoundedRectangle(cornerRadius: islandState == .compact ? 20 : 24)
+        ZStack(alignment: .bottom) {
+            // Background: attached mode has inverse top corners, detached has full rounded corners
+            if isAttached {
+                AttachedIslandShape(
+                    bottomRadius: islandState == .compact ? 20 : 24,
+                    inverseRadius: Self.earRadius
+                )
                 .fill(Color(white: 0.08))
                 .overlay(
-                    RoundedRectangle(cornerRadius: islandState == .compact ? 20 : 24)
-                        .strokeBorder(.white.opacity(0.15), lineWidth: 0.5)
+                    AttachedIslandShape(
+                        bottomRadius: islandState == .compact ? 20 : 24,
+                        inverseRadius: Self.earRadius
+                    )
+                    .stroke(.white.opacity(0.15), lineWidth: 0.5)
                 )
+            } else {
+                RoundedRectangle(cornerRadius: islandState == .compact ? 20 : 24)
+                    .fill(Color(white: 0.08))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: islandState == .compact ? 20 : 24)
+                            .strokeBorder(.white.opacity(0.15), lineWidth: 0.5)
+                    )
+            }
 
             // Content based on state — `tick` dependency ensures periodic redraws
+            // In attached mode, content is aligned to the bottom so it appears below the menu bar
             let _ = syncEngine.tick // swiftlint:disable:this redundant_discardable_let
-            switch islandState {
-            case .compact:
-                CompactIslandView(syncEngine: syncEngine, lyricsManager: lyricsManager, appState: appState)
-            case .expanded:
-                ExpandedIslandView(syncEngine: syncEngine, lyricsManager: lyricsManager, appState: appState)
-            case .full:
-                FullIslandView(syncEngine: syncEngine, lyricsManager: lyricsManager, appState: appState)
+            Group {
+                switch islandState {
+                case .compact:
+                    CompactIslandView(syncEngine: syncEngine, lyricsManager: lyricsManager, appState: appState)
+                case .expanded:
+                    ExpandedIslandView(syncEngine: syncEngine, lyricsManager: lyricsManager, appState: appState)
+                case .full:
+                    FullIslandView(syncEngine: syncEngine, lyricsManager: lyricsManager, appState: appState)
+                }
             }
+            .frame(height: Self.contentHeight(for: islandState, dualLine: appState.dualLineMode, artwork: appState.showArtwork))
+            .padding(.horizontal, isAttached ? Self.earRadius : 0)
         }
         .frame(width: widthForState, height: heightForState)
         .animation(.spring(response: 0.4, dampingFraction: 0.8), value: islandState)
         .animation(.spring(response: 0.4, dampingFraction: 0.8), value: appState.dualLineMode)
+        .animation(.spring(response: 0.4, dampingFraction: 0.8), value: appState.showArtwork)
         .onReceive(NotificationCenter.default.publisher(for: .islandTapped)) { _ in
             cycleState()
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .islandPositionModeChanged)) { notification in
+            if let mode = notification.object as? IslandPositionMode {
+                withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) {
+                    isAttached = mode == .attached
+                }
+                resizePanel(for: islandState)
+            }
         }
         .onChange(of: islandState) { _, newState in
             resizePanel(for: newState)
@@ -43,23 +73,49 @@ struct IslandContentView: View {
         .onChange(of: appState.showArtwork) { _, _ in
             resizePanel(for: islandState)
         }
-        .animation(.spring(response: 0.4, dampingFraction: 0.8), value: appState.showArtwork)
+    }
+
+    /// Height of the menu bar area (the part hidden behind the notch/menu bar).
+    static var menuBarHeight: CGFloat {
+        guard let screen = NSScreen.main else { return 25 }
+        return screen.frame.maxY - screen.visibleFrame.maxY
     }
 
     private var widthForState: CGFloat {
-        Self.size(for: islandState, dualLine: appState.dualLineMode, artwork: appState.showArtwork).width
+        size(for: islandState).width
     }
 
     private var heightForState: CGFloat {
-        Self.size(for: islandState, dualLine: appState.dualLineMode, artwork: appState.showArtwork).height
+        size(for: islandState).height
     }
 
-    static func size(for state: IslandState, dualLine: Bool = false, artwork: Bool = true) -> NSSize {
+    func size(for state: IslandState) -> NSSize {
+        Self.size(for: state, attached: isAttached, dualLine: appState.dualLineMode, artwork: appState.showArtwork)
+    }
+
+    /// The content-only height (without menu bar extension).
+    static func contentHeight(for state: IslandState, dualLine: Bool = false, artwork: Bool = true) -> CGFloat {
         switch state {
-        case .compact: NSSize(width: 350, height: dualLine ? 62 : artwork ? 48 : 38)
-        case .expanded: NSSize(width: artwork ? 450 : 380, height: artwork ? 160 : 120)
-        case .full: NSSize(width: artwork ? 540 : 400, height: artwork ? 340 : 300)
+        case .compact: dualLine ? 62 : artwork ? 48 : 38
+        case .expanded: artwork ? 160 : 120
+        case .full: artwork ? 340 : 300
         }
+    }
+
+    /// Radius of the inverse corner "ears" in attached mode.
+    static let earRadius: CGFloat = 10
+
+    static func size(for state: IslandState, attached: Bool = false, dualLine: Bool = false, artwork: Bool = true) -> NSSize {
+        let h = contentHeight(for: state, dualLine: dualLine, artwork: artwork)
+        let w: CGFloat = switch state {
+        case .compact: 350
+        case .expanded: artwork ? 450 : 380
+        case .full: artwork ? 540 : 400
+        }
+        if attached {
+            return NSSize(width: w, height: h + menuBarHeight)
+        }
+        return NSSize(width: w, height: h)
     }
 
     private func cycleState() {
@@ -72,6 +128,11 @@ struct IslandContentView: View {
 
     private func resizePanel(for state: IslandState) {
         guard let window = NSApp.windows.first(where: { $0 is DynamicIslandPanel }) as? DynamicIslandPanel else { return }
-        window.animateResize(to: Self.size(for: state, dualLine: appState.dualLineMode, artwork: appState.showArtwork))
+        window.animateResize(to: Self.size(
+            for: state,
+            attached: isAttached,
+            dualLine: appState.dualLineMode,
+            artwork: appState.showArtwork
+        ))
     }
 }

--- a/Sources/Window/DynamicIslandPanel.swift
+++ b/Sources/Window/DynamicIslandPanel.swift
@@ -3,9 +3,14 @@ import SwiftUI
 
 /// A borderless, always-on-top floating panel that mimics the iOS Dynamic Island.
 final class DynamicIslandPanel: NSPanel {
+    private(set) var positionMode: IslandPositionMode
+
     init(contentView: some View) {
+        positionMode = UserDefaults.standard.islandPositionMode
+        let initialSize = IslandContentView.size(for: .compact, attached: positionMode == .attached)
+
         super.init(
-            contentRect: NSRect(x: 0, y: 0, width: 350, height: 38),
+            contentRect: NSRect(origin: .zero, size: initialSize),
             styleMask: [.borderless, .nonactivatingPanel],
             backing: .buffered,
             defer: false
@@ -17,7 +22,7 @@ final class DynamicIslandPanel: NSPanel {
         hasShadow = false
         hidesOnDeactivate = false
         collectionBehavior = [.canJoinAllSpaces, .stationary, .fullScreenAuxiliary]
-        isMovableByWindowBackground = true
+        isMovableByWindowBackground = false
         animationBehavior = .utilityWindow
 
         let hostingView = NSHostingView(rootView: contentView)
@@ -30,7 +35,7 @@ final class DynamicIslandPanel: NSPanel {
         }
 
         // Use a plain transparent container to ensure no AppKit background leaks
-        let container = NSView(frame: NSRect(x: 0, y: 0, width: 350, height: 38))
+        let container = NSView(frame: NSRect(origin: .zero, size: initialSize))
         container.wantsLayer = true
         container.layer?.backgroundColor = .clear
         hostingView.translatesAutoresizingMaskIntoConstraints = false
@@ -44,16 +49,86 @@ final class DynamicIslandPanel: NSPanel {
 
         self.contentView = container
 
-        positionAtTopCenter()
+        applyPosition()
     }
+
+    // MARK: - Position Mode
+
+    /// Switch between attached and detached modes.
+    func setPositionMode(_ mode: IslandPositionMode) {
+        if positionMode == .detached {
+            saveDetachedPosition()
+        }
+
+        positionMode = mode
+        UserDefaults.standard.islandPositionMode = mode
+        applyPosition()
+
+        NotificationCenter.default.post(name: .islandPositionModeChanged, object: mode)
+    }
+
+    /// Position the panel according to the current mode.
+    private func applyPosition() {
+        switch positionMode {
+        case .attached:
+            positionAttachedToMenuBar()
+        case .detached:
+            if let saved = UserDefaults.standard.islandDetachedPosition {
+                setFrameOrigin(saved)
+            } else {
+                positionBelowMenuBar()
+            }
+        }
+    }
+
+    /// Center the panel horizontally, flush with the top of the screen (no gap).
+    private func positionAttachedToMenuBar() {
+        guard let screen = NSScreen.main else { return }
+        let x = screen.frame.midX - frame.width / 2
+        let y = screen.frame.maxY - frame.height
+        setFrameOrigin(NSPoint(x: x, y: y))
+    }
+
+    /// Position below the menu bar (default detached fallback).
+    private func positionBelowMenuBar() {
+        guard let screen = NSScreen.main else { return }
+        let screenFrame = screen.visibleFrame
+        let x = screenFrame.midX - frame.width / 2
+        let y = screenFrame.maxY - frame.height - 12
+        setFrameOrigin(NSPoint(x: x, y: y))
+    }
+
+    private func saveDetachedPosition() {
+        UserDefaults.standard.islandDetachedPosition = frame.origin
+    }
+
+    /// Whether the current position is close enough to snap back to attached mode.
+    private func isNearAttachedPosition() -> Bool {
+        guard let screen = NSScreen.main else { return false }
+        // Check if the top edge is near the top of the screen
+        let distanceFromTop = screen.frame.maxY - frame.maxY
+        return distanceFromTop < 20
+    }
+
+    // MARK: - Resize
 
     /// Animate the panel to a new size, keeping the top-center anchor point.
     func animateResize(to newSize: NSSize, duration: TimeInterval = 0.35) {
         let currentFrame = frame
 
-        // Keep the top-center pinned
-        let newX = currentFrame.midX - newSize.width / 2
-        let newY = currentFrame.maxY - newSize.height
+        let newX: CGFloat
+        let newY: CGFloat
+
+        if positionMode == .attached, let screen = NSScreen.main {
+            // In attached mode, always center horizontally on screen and pin to top
+            newX = screen.frame.midX - newSize.width / 2
+            newY = screen.frame.maxY - newSize.height
+        } else {
+            // In detached mode, keep the top-center pinned
+            newX = currentFrame.midX - newSize.width / 2
+            newY = currentFrame.maxY - newSize.height
+        }
+
         let newFrame = NSRect(origin: NSPoint(x: newX, y: newY), size: newSize)
 
         NSAnimationContext.runAnimationGroup { context in
@@ -63,33 +138,68 @@ final class DynamicIslandPanel: NSPanel {
         }
     }
 
-    /// Center the panel horizontally at the top of the main screen.
-    private func positionAtTopCenter() {
-        guard let screen = NSScreen.main else { return }
-        let screenFrame = screen.visibleFrame
-        let x = screenFrame.midX - frame.width / 2
-        let y = screenFrame.maxY - frame.height - 12
-        setFrameOrigin(NSPoint(x: x, y: y))
-    }
+    // MARK: - Mouse Handling
 
-    /// Track mouse movement to distinguish clicks from drags
     private var mouseDownOrigin: NSPoint?
+    private var windowOriginOnMouseDown: NSPoint?
+    private var isDragUnlocked = false
+    private var longPressTimer: Timer?
 
-    override func mouseDown(with event: NSEvent) {
+    /// How long the user must hold before dragging is allowed.
+    private static let longPressDuration: TimeInterval = 0.5
+
+    override func mouseDown(with _: NSEvent) {
         mouseDownOrigin = NSEvent.mouseLocation
-        super.mouseDown(with: event)
+        windowOriginOnMouseDown = frame.origin
+        isDragUnlocked = false
+
+        // Start long-press timer — when it fires, haptic feedback signals drag is ready
+        longPressTimer = Timer.scheduledTimer(withTimeInterval: Self.longPressDuration, repeats: false) { [weak self] _ in
+            guard let self else { return }
+            isDragUnlocked = true
+            NSHapticFeedbackManager.defaultPerformer.perform(.generic, performanceTime: .now)
+
+            // Immediately switch to detached visual state
+            if positionMode == .attached {
+                positionMode = .detached
+                UserDefaults.standard.islandPositionMode = .detached
+                NotificationCenter.default.post(name: .islandPositionModeChanged, object: IslandPositionMode.detached)
+            }
+        }
     }
 
-    override func mouseUp(with event: NSEvent) {
+    override func mouseDragged(with _: NSEvent) {
+        guard isDragUnlocked, let origin = mouseDownOrigin, let windowOrigin = windowOriginOnMouseDown else { return }
+
+        let current = NSEvent.mouseLocation
+        let newX = windowOrigin.x + (current.x - origin.x)
+        let newY = windowOrigin.y + (current.y - origin.y)
+        setFrameOrigin(NSPoint(x: newX, y: newY))
+    }
+
+    override func mouseUp(with _: NSEvent) {
+        longPressTimer?.invalidate()
+        longPressTimer = nil
+
         if let origin = mouseDownOrigin {
             let end = NSEvent.mouseLocation
             let distance = hypot(end.x - origin.x, end.y - origin.y)
+
             if distance < 5 {
+                // Click — toggle island state
                 NotificationCenter.default.post(name: .islandTapped, object: nil)
+            } else if isDragUnlocked {
+                // Drag ended — snap back to attached if near top, otherwise save detached position
+                if isNearAttachedPosition() {
+                    setPositionMode(.attached)
+                } else {
+                    saveDetachedPosition()
+                }
             }
         }
         mouseDownOrigin = nil
-        super.mouseUp(with: event)
+        windowOriginOnMouseDown = nil
+        isDragUnlocked = false
     }
 
     override var canBecomeKey: Bool {
@@ -103,4 +213,5 @@ final class DynamicIslandPanel: NSPanel {
 
 extension Notification.Name {
     static let islandTapped = Notification.Name("islandTapped")
+    static let islandPositionModeChanged = Notification.Name("islandPositionModeChanged")
 }

--- a/Sources/Window/IslandPositionMode.swift
+++ b/Sources/Window/IslandPositionMode.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+/// Whether the island is attached to the menu bar or freely draggable.
+enum IslandPositionMode: String {
+    /// Centered in the menu bar region, like an iPhone Dynamic Island.
+    case attached
+    /// Freely draggable to any screen position.
+    case detached
+}
+
+// MARK: - UserDefaults Persistence
+
+extension UserDefaults {
+    private enum Keys {
+        static let positionMode = "islandPositionMode"
+        static let detachedX = "islandDetachedX"
+        static let detachedY = "islandDetachedY"
+        static let hasDetachedPosition = "islandHasDetachedPosition"
+    }
+
+    var islandPositionMode: IslandPositionMode {
+        get {
+            guard let raw = string(forKey: Keys.positionMode) else { return .attached }
+            return IslandPositionMode(rawValue: raw) ?? .attached
+        }
+        set { set(newValue.rawValue, forKey: Keys.positionMode) }
+    }
+
+    var islandDetachedPosition: NSPoint? {
+        get {
+            guard bool(forKey: Keys.hasDetachedPosition) else { return nil }
+            return NSPoint(
+                x: double(forKey: Keys.detachedX),
+                y: double(forKey: Keys.detachedY)
+            )
+        }
+        set {
+            if let point = newValue {
+                set(true, forKey: Keys.hasDetachedPosition)
+                set(point.x, forKey: Keys.detachedX)
+                set(point.y, forKey: Keys.detachedY)
+            } else {
+                set(false, forKey: Keys.hasDetachedPosition)
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add two island position modes: **attached** (flush with menu bar, concave inverse corner ears) and **detached** (freely draggable)
- Long-press (0.5s) with haptic feedback required before dragging, preventing accidental repositioning
- Dragging near screen top snaps back to attached mode; position preference persists across launches
- Menu bar toggle (⌘P) to switch between modes

Fixes #7

## Test plan
- [ ] Launch app → island appears attached to menu bar with inverse corner ears
- [ ] Short click → cycles island state (compact/expanded/full), no dragging
- [ ] Long-press (0.5s) → feel haptic feedback, island switches to detached shape, then drag freely
- [ ] Drag near top of screen → snaps back to attached mode
- [ ] Menu bar ⌘P → toggles between attached/detached
- [ ] Quit and relaunch → position mode persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)