### PR TITLE
fix(views): scroll lyrics to current line on initial Full mode entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 ### Fixed
 
 - Expanded 灵动岛歌词改为逐行平滑滚动（ScrollViewReader + scrollTo），替代原有滑动窗口就地刷新；移除 Expanded 视图中对双行歌词模式的引用，双行模式仅作用于 Compact 状态 (#33)
+- 首次进入 Full 模式时歌词不会自动滚动到当前播放行，需等下一次行切换才会滚动 (#39)
 - 菜单栏点击"设置"无反应：LSUIElement 应用中私有 selector 不可靠，改为手动管理 Settings 窗口 (#31)
 - 修复长歌词行 MarqueeText 不再自动滚动的问题：`.id()` 导致视图重建时 `@State` 重置，GeometryReader 尚未测量完成动画就已退出 (#28)
 - 自由拖拽模式下拖动灵动岛不再需要长按 0.5 秒，鼠标按下即可直接拖拽 (#25)

--- a/Sources/Views/LyricsScrollView.swift
+++ b/Sources/Views/LyricsScrollView.swift
@@ -28,6 +28,9 @@ struct LyricsScrollView: View {
                 }
                 .padding(.horizontal, 20)
             }
+            .onAppear {
+                proxy.scrollTo(currentLineIndex, anchor: .center)
+            }
             .onChange(of: currentLineIndex) { _, newIdx in
                 withAnimation(.easeInOut(duration: 0.3)) {
                     proxy.scrollTo(newIdx, anchor: .center)


### PR DESCRIPTION
## Summary
- 首次进入 Full 模式时，歌词列表立即滚动到当前播放行，而非停留在顶部等待下一次行切换
- 在 `LyricsScrollView` 的 `ScrollViewReader` 中添加 `.onAppear` 修饰符执行初始滚动

Fixes #39

## Test plan
- [ ] 播放一首已过前几行歌词的歌曲
- [ ] 从 Compact 点击两次进入 Full 模式
- [ ] 确认歌词立即定位到当前播放行（居中显示）
- [ ] 确认后续行切换时滚动动画仍正常工作

🤖 Generated with [Claude Code](https://claude.com/claude-code)