### PR TITLE
feat(help): add built-in help/manual accessible from menu bar

### DIFF
--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -6,6 +6,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var islandPanel: DynamicIslandPanel?
     private var onboardingWindow: NSWindow?
     private var settingsWindow: NSWindow?
+    private var helpWindow: NSWindow?
     private var statusItem: NSStatusItem?
     private let spotifyService = SpotifyAppleScriptService()
     private let lyricsManager = LyricsManager()
@@ -97,6 +98,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         menu.addItem(.separator())
         menu.addItem(NSMenuItem(title: String(localized: "menu.settings"), action: #selector(openSettings), keyEquivalent: ","))
+        menu.addItem(NSMenuItem(title: String(localized: "menu.help"), action: #selector(openHelp), keyEquivalent: "?"))
         menu.addItem(NSMenuItem(title: String(localized: "menu.quit"), action: #selector(quitApp), keyEquivalent: "q"))
 
         statusItem?.menu = menu
@@ -245,6 +247,28 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         } else {
             islandPanel?.orderFrontRegardless()
         }
+    }
+
+    @objc private func openHelp() {
+        if let window = helpWindow {
+            window.makeKeyAndOrderFront(nil)
+        } else {
+            let window = NSWindow(
+                contentRect: NSRect(x: 0, y: 0, width: 420, height: 480),
+                styleMask: [.titled, .closable],
+                backing: .buffered,
+                defer: false
+            )
+            window.center()
+            window.title = String(localized: "menu.help")
+            window.contentView = NSHostingView(rootView: HelpView())
+            window.isReleasedWhenClosed = false
+            window.titlebarAppearsTransparent = true
+            window.backgroundColor = NSColor(white: 0.1, alpha: 1)
+            helpWindow = window
+            window.makeKeyAndOrderFront(nil)
+        }
+        NSApp.activate()
     }
 
     @objc private func openSettings() {

--- a/Sources/Resources/Localizable.xcstrings
+++ b/Sources/Resources/Localizable.xcstrings
@@ -433,6 +433,126 @@
         "en": { "stringUnit": { "state": "translated", "value": "Report Issue" } },
         "zh-Hans": { "stringUnit": { "state": "translated", "value": "反馈问题" } }
       }
+    },
+    "menu.help": {
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Help" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "帮助" } }
+      }
+    },
+    "help.title": {
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Lyrisland Help" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "Lyrisland 帮助" } }
+      }
+    },
+    "help.section.interactions": {
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Island Interactions" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "灵动岛交互" } }
+      }
+    },
+    "help.interactions.click": {
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Click the island to cycle through states: Compact → Expanded → Full → Compact." } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "点击灵动岛切换状态：紧凑 → 展开 → 完整 → 紧凑。" } }
+      }
+    },
+    "help.interactions.longpress": {
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Long-press (hold for 0.5s) the island to detach it from the menu bar and unlock dragging." } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "长按灵动岛（按住 0.5 秒）可将其从菜单栏脱离，解锁拖拽功能。" } }
+      }
+    },
+    "help.interactions.drag": {
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Once detached, drag the island to reposition it anywhere on screen." } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "脱离后可拖拽灵动岛至屏幕任意位置。" } }
+      }
+    },
+    "help.interactions.snap": {
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Drag the island back near the top of the screen to snap it back to the menu bar." } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "将灵动岛拖拽至屏幕顶部附近即可自动吸附回菜单栏。" } }
+      }
+    },
+    "help.section.settings": {
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Settings" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "设置说明" } }
+      }
+    },
+    "help.settings.position": {
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Position Mode — switch between Attached (pinned to menu bar) and Detached (free-floating) modes." } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "位置模式 — 在吸附（固定于菜单栏）和自由（浮动拖拽）模式之间切换。" } }
+      }
+    },
+    "help.settings.artwork": {
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Show Artwork — display album cover art alongside lyrics in the island." } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "显示专辑封面 — 在灵动岛中展示当前播放歌曲的封面图片。" } }
+      }
+    },
+    "help.settings.dualline": {
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Dual-Line Mode — show the current lyric line and the next line together." } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "双行模式 — 同时显示当前歌词和下一行歌词。" } }
+      }
+    },
+    "help.settings.alignment": {
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Lyrics Alignment — choose left, center, or right alignment for lyrics text." } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "歌词对齐 — 选择歌词文本的对齐方式：左对齐、居中或右对齐。" } }
+      }
+    },
+    "help.settings.offset": {
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Lyrics Offset — adjust timing offset when lyrics are out of sync. Use ±0.5s buttons or ⌘[ / ⌘] shortcuts." } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "歌词偏移 — 当歌词不同步时调整时间偏移。可使用 ±0.5 秒按钮或 ⌘[ / ⌘] 快捷键。" } }
+      }
+    },
+    "help.section.shortcuts": {
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Keyboard Shortcuts" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "键盘快捷键" } }
+      }
+    },
+    "help.shortcuts.toggle": {
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "⌘L — Show or hide the lyrics island." } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "⌘L — 显示或隐藏歌词灵动岛。" } }
+      }
+    },
+    "help.shortcuts.settings": {
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "⌘, — Open the Settings window." } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "⌘, — 打开设置窗口。" } }
+      }
+    },
+    "help.shortcuts.help": {
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "⌘? — Open this Help window." } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "⌘? — 打开此帮助窗口。" } }
+      }
+    },
+    "help.shortcuts.quit": {
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "⌘Q — Quit Lyrisland." } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "⌘Q — 退出 Lyrisland。" } }
+      }
+    },
+    "help.section.providers": {
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Lyrics Providers" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "歌词来源" } }
+      }
+    },
+    "help.providers.chain": {
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Lyrics are fetched from multiple sources in order: LRCLIB → Musixmatch → Soda Music → Netease. The first source that returns synced lyrics wins." } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "歌词按优先级依次从多个来源获取：LRCLIB → Musixmatch → 汽水音乐 → 网易云。首个返回同步歌词的来源将被采用。" } }
+      }
     }
   }
 }

--- a/Sources/Views/HelpView.swift
+++ b/Sources/Views/HelpView.swift
@@ -1,0 +1,149 @@
+import SwiftUI
+
+struct HelpView: View {
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 24) {
+                // Header
+                VStack(spacing: 8) {
+                    Image(systemName: "questionmark.circle")
+                        .font(.system(size: 48))
+                        .foregroundStyle(.white)
+                    Text(String(localized: "help.title"))
+                        .font(.system(size: 24, weight: .bold))
+                        .foregroundStyle(.white)
+                }
+                .frame(maxWidth: .infinity)
+                .padding(.top, 24)
+                .padding(.bottom, 8)
+
+                // Island Interactions
+                helpSection(
+                    title: String(localized: "help.section.interactions"),
+                    icon: "hand.tap",
+                    items: [
+                        HelpItem(
+                            icon: "cursorarrow.click.2",
+                            text: String(localized: "help.interactions.click")
+                        ),
+                        HelpItem(
+                            icon: "hand.point.up.left.and.text",
+                            text: String(localized: "help.interactions.longpress")
+                        ),
+                        HelpItem(
+                            icon: "arrow.up.and.down.and.arrow.left.and.right",
+                            text: String(localized: "help.interactions.drag")
+                        ),
+                        HelpItem(
+                            icon: "arrow.uturn.up",
+                            text: String(localized: "help.interactions.snap")
+                        ),
+                    ]
+                )
+
+                // Settings
+                helpSection(
+                    title: String(localized: "help.section.settings"),
+                    icon: "gearshape",
+                    items: [
+                        HelpItem(
+                            icon: "pin",
+                            text: String(localized: "help.settings.position")
+                        ),
+                        HelpItem(
+                            icon: "photo",
+                            text: String(localized: "help.settings.artwork")
+                        ),
+                        HelpItem(
+                            icon: "text.line.first.and.arrowtriangle.forward",
+                            text: String(localized: "help.settings.dualline")
+                        ),
+                        HelpItem(
+                            icon: "text.alignleft",
+                            text: String(localized: "help.settings.alignment")
+                        ),
+                        HelpItem(
+                            icon: "clock.arrow.2.circlepath",
+                            text: String(localized: "help.settings.offset")
+                        ),
+                    ]
+                )
+
+                // Keyboard Shortcuts
+                helpSection(
+                    title: String(localized: "help.section.shortcuts"),
+                    icon: "keyboard",
+                    items: [
+                        HelpItem(
+                            icon: "eye",
+                            text: String(localized: "help.shortcuts.toggle")
+                        ),
+                        HelpItem(
+                            icon: "gearshape",
+                            text: String(localized: "help.shortcuts.settings")
+                        ),
+                        HelpItem(
+                            icon: "questionmark.circle",
+                            text: String(localized: "help.shortcuts.help")
+                        ),
+                        HelpItem(
+                            icon: "power",
+                            text: String(localized: "help.shortcuts.quit")
+                        ),
+                    ]
+                )
+
+                // Lyrics Providers
+                helpSection(
+                    title: String(localized: "help.section.providers"),
+                    icon: "music.note.list",
+                    items: [
+                        HelpItem(
+                            icon: "text.quote",
+                            text: String(localized: "help.providers.chain")
+                        ),
+                    ]
+                )
+            }
+            .padding(.horizontal, 32)
+            .padding(.bottom, 24)
+        }
+        .frame(width: 420, height: 480)
+    }
+
+    // MARK: - Helpers
+
+    private struct HelpItem {
+        let icon: String
+        let text: String
+    }
+
+    private func helpSection(title: String, icon: String, items: [HelpItem]) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Label {
+                Text(title)
+                    .font(.system(size: 15, weight: .semibold))
+            } icon: {
+                Image(systemName: icon)
+                    .font(.system(size: 13))
+            }
+            .foregroundStyle(.white)
+
+            VStack(alignment: .leading, spacing: 8) {
+                ForEach(Array(items.enumerated()), id: \.offset) { _, item in
+                    HStack(alignment: .top, spacing: 10) {
+                        Image(systemName: item.icon)
+                            .font(.system(size: 12))
+                            .foregroundStyle(.white.opacity(0.6))
+                            .frame(width: 18)
+                        Text(item.text)
+                            .font(.system(size: 13))
+                            .foregroundStyle(.white.opacity(0.8))
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
+            }
+            .padding(.leading, 4)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add a lightweight in-app Help window (⌘?) with sections covering island interactions, settings, keyboard shortcuts, and lyrics providers
- Add "Help" menu item to the menu bar dropdown (after Settings, before Quit)
- Full en/zh-Hans localization for all help content (17 new string entries)

Fixes #38

## Test plan
- [ ] Build and launch the app
- [ ] Verify "Help" appears in the menu bar dropdown between Settings and Quit
- [ ] Click Help → scrollable help window opens with dark theme
- [ ] Verify all 4 sections render correctly: Interactions, Settings, Shortcuts, Providers
- [ ] Close and reopen Help → window is reused (no duplicate windows)
- [ ] Test ⌘? shortcut opens the help window
- [ ] Switch system language to zh-Hans and verify Chinese translations

🤖 Generated with [Claude Code](https://claude.com/claude-code)