### PR TITLE
fix(lyrics): clear stale lyrics immediately on track switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 ### Fixed
 
+- 切换歌曲时旧歌词短暂闪现：在加载新歌词前立即清除 `currentLyrics`，避免 UI 显示上一首歌的歌词 (#50)
 - Expanded 灵动岛歌词改为逐行平滑滚动（ScrollViewReader + scrollTo），替代原有滑动窗口就地刷新；移除 Expanded 视图中对双行歌词模式的引用，双行模式仅作用于 Compact 状态 (#33)
 - 首次进入 Full 模式时歌词不会自动滚动到当前播放行，需等下一次行切换才会滚动 (#39)
 - 菜单栏点击"设置"无反应：LSUIElement 应用中私有 selector 不可靠，改为手动管理 Settings 窗口 (#31)

--- a/Sources/Lyrics/LyricsManager.swift
+++ b/Sources/Lyrics/LyricsManager.swift
@@ -49,6 +49,9 @@ final class LyricsManager: ObservableObject {
     )
 
     func loadLyrics(for track: TrackInfo) async {
+        // Clear stale lyrics immediately so the UI never shows the previous track's lyrics
+        currentLyrics = nil
+
         // Check cache (memory → disk)
         if let cached = await cache.get(track.id) {
             logDebug("Lyrics cache hit for: \(track.title) — \(track.artist)")


### PR DESCRIPTION
## Summary
- 切换歌曲时，在 `loadLyrics(for:)` 开头立即将 `currentLyrics` 设为 `nil`，避免旧歌词在新歌词加载前短暂闪现

## Details
当切换歌曲时，`loadLyrics` 是异步方法，在 `await` cache/provider 之前没有清除旧歌词，导致 UI 短暂显示上一首歌的歌词。修复方法是在方法入口处立即清除 `currentLyrics`，因为该方法在 `@MainActor` 上执行，`nil` 赋值在任何 suspension point 之前同步完成。

Fixes #50

## Test plan
- [ ] 播放一首有歌词的歌曲，确认歌词正常显示
- [ ] 切换到下一首歌，确认旧歌词立即消失，不会短暂闪现
- [ ] 切换到缓存中已有歌词的歌曲，确认歌词几乎立即显示（cache hit 路径）
- [ ] 切换到没有歌词的歌曲，确认 UI 正确显示无歌词状态

🤖 Generated with [Claude Code](https://claude.com/claude-code)