### PR TITLE
fix(views): align loading/empty state padding with lyrics view in Full mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Full 模式歌词加载过程中封面图片布局偏移
+
 ### Added
 
 - GitHub Actions release workflow：push tag 自动构建并发布 DMG + zip 到 GitHub Releases

--- a/Sources/Views/FullIslandView.swift
+++ b/Sources/Views/FullIslandView.swift
@@ -40,16 +40,21 @@ struct FullIslandView: View {
                     alignment: appState.resolvedLyricsAlignment
                 )
             } else if lyricsManager.isLoading {
-                Spacer()
-                ProgressView()
-                    .scaleEffect(0.7)
-                    .tint(.white.opacity(0.5))
-                Spacer()
+                VStack {
+                    Spacer()
+                    ProgressView()
+                        .scaleEffect(0.7)
+                        .tint(.white.opacity(0.5))
+                    Spacer()
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .padding(.horizontal, 20)
             } else {
                 Text("lyrics.no_synced")
                     .font(.system(size: 13))
                     .foregroundStyle(.white.opacity(0.4))
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .padding(.horizontal, 20)
             }
         }
     }


### PR DESCRIPTION
## Summary
- Full 模式下歌词加载状态（ProgressView）和无歌词状态添加 `.padding(.horizontal, 20)`，与 `LyricsScrollView` 的 padding 保持一致
- 修复切换歌曲时封面图片因左右列可用空间变化而发生布局偏移的问题

Fixes #68

## Test plan
- [ ] 播放一首歌曲，进入 Full 模式
- [ ] 切换到新歌，观察歌词加载过程中封面图片位置是否保持稳定
- [ ] 播放一首无歌词的歌曲，确认封面位置与有歌词时一致

🤖 Generated with [Claude Code](https://claude.com/claude-code)