### PR TITLE
fix(views): apply blur effect to translation lines in LyricsScrollView

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@
 ### Fixed
 
 - Full 模式歌词加载过程中封面图片布局偏移
+<<<<<<< HEAD
 - Full 模式长歌词行换行而非使用 MarqueeText 单行滚动显示
+- Full 模式远处歌词行的翻译缺少 blur 模糊效果
 
 ### Added
 


### PR DESCRIPTION
## Summary
- 为 `LyricLineRow` 中的翻译文本添加 `.blur(radius: blurAmount)` 修饰符
- 使远处歌词行（distance > 2）的翻译与主歌词保持一致的模糊效果

Fixes #70

## Test plan
- [ ] 播放一首带翻译的歌曲，进入 Full 模式
- [ ] 观察距离当前行较远的歌词行，确认翻译文本也有 blur 模糊效果
- [ ] 确认当前行的翻译文本没有模糊（distance == 0）

🤖 Generated with [Claude Code](https://claude.com/claude-code)