### PR TITLE
feat(views): introduce rem-based font sizing for customizable lyrics scale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Added
 
+- rem-based 字体缩放机制：所有歌词相关字体大小基于可配置的根字体大小按比例缩放，可在设置窗口外观标签页中调节
 - GitHub Actions release workflow：push tag 自动构建并发布 DMG + zip 到 GitHub Releases
 - DMG 安装包：浅色渐变背景 + 拖拽到 Applications 引导箭头
 

--- a/Sources/App/AppState.swift
+++ b/Sources/App/AppState.swift
@@ -40,6 +40,10 @@ final class AppState: ObservableObject {
         didSet { UserDefaults.standard.set(backgroundStyle.rawValue, forKey: "backgroundStyle") }
     }
 
+    @Published var rootFontSize: Double {
+        didSet { UserDefaults.standard.set(rootFontSize, forKey: "rootFontSize") }
+    }
+
     /// Hex string for the user's custom solid background color (e.g. "#141414").
     @Published var solidColorHex: String {
         didSet { UserDefaults.standard.set(solidColorHex, forKey: "solidColorHex") }
@@ -61,11 +65,14 @@ final class AppState: ObservableObject {
             "lyricsAlignment": "center",
             "backgroundStyle": "solid",
             "solidColorHex": "#141414",
+            "rootFontSize": 16.0,
         ])
         showArtwork = UserDefaults.standard.bool(forKey: "showArtwork")
         lyricsAlignment = UserDefaults.standard.string(forKey: "lyricsAlignment") ?? "center"
         backgroundStyle = BackgroundStyle(rawValue: UserDefaults.standard.string(forKey: "backgroundStyle") ?? "solid") ?? .solid
         solidColorHex = UserDefaults.standard.string(forKey: "solidColorHex") ?? "#141414"
+        let storedFontSize = UserDefaults.standard.double(forKey: "rootFontSize")
+        rootFontSize = storedFontSize > 0 ? storedFontSize : 16.0
 
         // Sync changes from @AppStorage (Settings window) back to @Published properties
         defaultsObserver = NotificationCenter.default
@@ -83,6 +90,9 @@ final class AppState: ObservableObject {
                 if backgroundStyle != newBgStyle { backgroundStyle = newBgStyle }
                 let newSolidHex = UserDefaults.standard.string(forKey: "solidColorHex") ?? "#141414"
                 if solidColorHex != newSolidHex { solidColorHex = newSolidHex }
+                let newFontSize = UserDefaults.standard.double(forKey: "rootFontSize")
+                let resolvedFontSize = newFontSize > 0 ? newFontSize : 16.0
+                if rootFontSize != resolvedFontSize { rootFontSize = resolvedFontSize }
             }
     }
 

--- a/Sources/Resources/Localizable.xcstrings
+++ b/Sources/Resources/Localizable.xcstrings
@@ -2178,6 +2178,108 @@
         }
       }
     },
+    "settings.appearance.font_size": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Font Size"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "字体大小"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "字體大小"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "フォントサイズ"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "글꼴 크기"
+          }
+        }
+      }
+    },
+    "settings.appearance.font_size_section": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Font Size"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "字体大小"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "字體大小"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "フォントサイズ"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "글꼴 크기"
+          }
+        }
+      }
+    },
+    "settings.appearance.font_size_reset": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reset"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重置"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重設"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "リセット"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "재설정"
+          }
+        }
+      }
+    },
     "settings.appearance.display_section": {
       "localizations": {
         "en": {

--- a/Sources/Utils/RemScaling.swift
+++ b/Sources/Utils/RemScaling.swift
@@ -1,0 +1,24 @@
+import SwiftUI
+
+// MARK: - Environment Key
+
+private struct RootFontSizeKey: EnvironmentKey {
+    static let defaultValue: CGFloat = 16
+}
+
+extension EnvironmentValues {
+    var rootFontSize: CGFloat {
+        get { self[RootFontSizeKey.self] }
+        set { self[RootFontSizeKey.self] = newValue }
+    }
+}
+
+// MARK: - rem helper
+
+extension CGFloat {
+    /// Computes an absolute font size from a `rem` multiplier and a root size.
+    /// Usage: `CGFloat.rem(0.75, root: rootFontSize)` -> 12 when root = 16.
+    static func rem(_ multiplier: CGFloat, root: CGFloat) -> CGFloat {
+        multiplier * root
+    }
+}

--- a/Sources/Views/CompactIslandView.swift
+++ b/Sources/Views/CompactIslandView.swift
@@ -6,6 +6,7 @@ struct CompactIslandView: View {
     @ObservedObject var syncEngine: PlaybackSyncEngine
     @ObservedObject var lyricsManager: LyricsManager
     @ObservedObject var appState: AppState
+    @Environment(\.rootFontSize) private var rootFontSize
 
     var body: some View {
         HStack(spacing: 10) {
@@ -15,7 +16,7 @@ struct CompactIslandView: View {
                     .frame(width: 16, height: 16)
             } else {
                 Image(systemName: statusIcon)
-                    .font(.system(size: 10))
+                    .font(.system(size: .rem(0.625, root: rootFontSize)))
                     .foregroundStyle(.white.opacity(0.6))
             }
 
@@ -29,7 +30,8 @@ struct CompactIslandView: View {
                         DualLineRow(
                             text: lyrics.lines[lineIdx].text,
                             isCurrent: lineIdx == idx,
-                            lineDuration: lineDuration(for: lineIdx, in: lyrics)
+                            lineDuration: lineDuration(for: lineIdx, in: lyrics),
+                            rootFontSize: rootFontSize
                         )
                         .environment(\.layoutDirection, lyrics.lines[lineIdx].text.isRTL ? .rightToLeft : .leftToRight)
                         .transition(.push(from: .bottom).combined(with: .opacity))
@@ -41,7 +43,7 @@ struct CompactIslandView: View {
                 // Single-line mode: original MarqueeText behavior
                 MarqueeText(
                     text: displayText,
-                    font: .system(size: 13, weight: .medium),
+                    font: .system(size: .rem(0.8125, root: rootFontSize), weight: .medium),
                     color: displayTextOpacity,
                     loops: false,
                     lineDuration: currentLineDuration
@@ -119,11 +121,14 @@ private struct DualLineRow: View, Equatable {
     let text: String
     let isCurrent: Bool
     var lineDuration: Double?
+    let rootFontSize: CGFloat
 
     var body: some View {
         MarqueeText(
             text: text,
-            font: isCurrent ? .system(size: 13, weight: .medium) : .system(size: 11),
+            font: isCurrent
+                ? .system(size: .rem(0.8125, root: rootFontSize), weight: .medium)
+                : .system(size: .rem(0.6875, root: rootFontSize)),
             color: isCurrent ? .white : .white.opacity(0.4),
             scrollEnabled: isCurrent,
             loops: false,

--- a/Sources/Views/ExpandedIslandView.swift
+++ b/Sources/Views/ExpandedIslandView.swift
@@ -6,6 +6,7 @@ struct ExpandedIslandView: View {
     @ObservedObject var syncEngine: PlaybackSyncEngine
     @ObservedObject var lyricsManager: LyricsManager
     @ObservedObject var appState: AppState
+    @Environment(\.rootFontSize) private var rootFontSize
 
     private let visibleLineCount = 5
 
@@ -15,15 +16,15 @@ struct ExpandedIslandView: View {
             if let title = syncEngine.trackTitle {
                 HStack(spacing: 4) {
                     Text(title)
-                        .font(.system(size: 11, weight: .semibold))
+                        .font(.system(size: .rem(0.6875, root: rootFontSize), weight: .semibold))
                         .foregroundStyle(.white.opacity(0.5))
                         .lineLimit(1)
                     if let artist = syncEngine.trackArtist {
                         Text("—")
-                            .font(.system(size: 11))
+                            .font(.system(size: .rem(0.6875, root: rootFontSize)))
                             .foregroundStyle(.white.opacity(0.3))
                         Text(artist)
-                            .font(.system(size: 11))
+                            .font(.system(size: .rem(0.6875, root: rootFontSize)))
                             .foregroundStyle(.white.opacity(0.4))
                             .lineLimit(1)
                     }
@@ -46,7 +47,7 @@ struct ExpandedIslandView: View {
                     if isCurrent {
                         MarqueeText(
                             text: line.text,
-                            font: .system(size: 15, weight: .bold),
+                            font: .system(size: .rem(0.9375, root: rootFontSize), weight: .bold),
                             color: .white,
                             loops: false,
                             lineDuration: lineDuration(for: currentIdx, in: lyrics)
@@ -58,7 +59,7 @@ struct ExpandedIslandView: View {
                     } else {
                         Text(line.text)
                             .font(.system(
-                                size: distance == 1 ? 13 : 12,
+                                size: .rem(distance == 1 ? 0.8125 : 0.75, root: rootFontSize),
                                 weight: distance == 1 ? .medium : .regular
                             ))
                             .foregroundStyle(.white.opacity(opacityFor(distance: distance)))
@@ -73,7 +74,7 @@ struct ExpandedIslandView: View {
                 .id(currentIdx)
             } else {
                 Text("lyrics.no_lyrics")
-                    .font(.system(size: 13))
+                    .font(.system(size: .rem(0.8125, root: rootFontSize)))
                     .foregroundStyle(.white.opacity(0.4))
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
             }

--- a/Sources/Views/FullIslandView.swift
+++ b/Sources/Views/FullIslandView.swift
@@ -5,6 +5,7 @@ struct FullIslandView: View {
     @ObservedObject var syncEngine: PlaybackSyncEngine
     @ObservedObject var lyricsManager: LyricsManager
     @ObservedObject var appState: AppState
+    @Environment(\.rootFontSize) private var rootFontSize
 
     var body: some View {
         // Lyrics — artwork is handled by parent IslandContentView
@@ -15,13 +16,13 @@ struct FullIslandView: View {
                     VStack(alignment: .leading, spacing: 2) {
                         if let title = syncEngine.trackTitle {
                             Text(title)
-                                .font(.system(size: 13, weight: .semibold))
+                                .font(.system(size: .rem(0.8125, root: rootFontSize), weight: .semibold))
                                 .foregroundStyle(.white.opacity(0.8))
                                 .lineLimit(1)
                         }
                         if let artist = syncEngine.trackArtist {
                             Text(artist)
-                                .font(.system(size: 11))
+                                .font(.system(size: .rem(0.6875, root: rootFontSize)))
                                 .foregroundStyle(.white.opacity(0.5))
                                 .lineLimit(1)
                         }
@@ -51,7 +52,7 @@ struct FullIslandView: View {
                 .padding(.horizontal, 20)
             } else {
                 Text("lyrics.no_synced")
-                    .font(.system(size: 13))
+                    .font(.system(size: .rem(0.8125, root: rootFontSize)))
                     .foregroundStyle(.white.opacity(0.4))
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                     .padding(.horizontal, 20)

--- a/Sources/Views/IslandContentView.swift
+++ b/Sources/Views/IslandContentView.swift
@@ -74,6 +74,7 @@ struct IslandContentView: View {
             .padding(.horizontal, showAttachedAppearance ? Self.earRadius : 0)
             .padding(contentPadding)
         }
+        .environment(\.rootFontSize, appState.rootFontSize)
         // Fill the panel. In detached mode, cap to the exact panel height so
         // the clipShape aligns with the NSPanel edges (prevents corner overflow).
         .frame(
@@ -121,6 +122,10 @@ struct IslandContentView: View {
 
     // MARK: - Artwork (single persistent instance)
 
+    private var rootFontSize: CGFloat {
+        appState.rootFontSize
+    }
+
     private var artworkColumn: some View {
         VStack(spacing: 0) {
             ArtworkView(trackId: syncEngine.currentTrackId, artworkURL: syncEngine.artworkURL, size: artworkSize)
@@ -129,7 +134,7 @@ struct IslandContentView: View {
             if islandState == .full {
                 if let source = lyricsManager.currentLyrics?.source {
                     Text(source)
-                        .font(.system(size: 9, weight: .medium))
+                        .font(.system(size: .rem(0.5625, root: rootFontSize), weight: .medium))
                         .foregroundStyle(.white.opacity(0.3))
                         .padding(.horizontal, 8)
                         .padding(.vertical, 2)
@@ -141,13 +146,13 @@ struct IslandContentView: View {
                 VStack(spacing: 2) {
                     if let title = syncEngine.trackTitle {
                         Text(title)
-                            .font(.system(size: 12, weight: .semibold))
+                            .font(.system(size: .rem(0.75, root: rootFontSize), weight: .semibold))
                             .foregroundStyle(.white.opacity(0.8))
                             .lineLimit(1)
                     }
                     if let artist = syncEngine.trackArtist {
                         Text(artist)
-                            .font(.system(size: 11))
+                            .font(.system(size: .rem(0.6875, root: rootFontSize)))
                             .foregroundStyle(.white.opacity(0.5))
                             .lineLimit(1)
                     }

--- a/Sources/Views/LyricsScrollView.swift
+++ b/Sources/Views/LyricsScrollView.swift
@@ -6,6 +6,7 @@ struct LyricsScrollView: View {
     let lyrics: SyncedLyrics
     let currentLineIndex: Int
     var alignment: Alignment = .leading
+    @Environment(\.rootFontSize) private var rootFontSize
 
     var body: some View {
         ScrollViewReader { proxy in
@@ -19,7 +20,8 @@ struct LyricsScrollView: View {
                             translation: line.translation,
                             isCurrent: line.id == currentLineIndex,
                             distance: abs(line.id - currentLineIndex),
-                            lineDuration: lineDuration(for: line.id)
+                            lineDuration: lineDuration(for: line.id),
+                            rootFontSize: rootFontSize
                         )
                         .frame(maxWidth: .infinity, alignment: alignment)
                         .environment(\.layoutDirection, line.text.isRTL ? .rightToLeft : .leftToRight)
@@ -55,20 +57,21 @@ private struct LyricLineRow: View, Equatable {
     let isCurrent: Bool
     let distance: Int
     let lineDuration: Double?
+    let rootFontSize: CGFloat
 
     var body: some View {
         VStack(spacing: 2) {
             if isCurrent {
                 MarqueeText(
                     text: text,
-                    font: .system(size: 15, weight: .bold),
+                    font: .system(size: .rem(0.9375, root: rootFontSize), weight: .bold),
                     color: .white,
                     loops: false,
                     lineDuration: lineDuration
                 )
             } else {
                 Text(text)
-                    .font(.system(size: 12))
+                    .font(.system(size: .rem(0.75, root: rootFontSize)))
                     .foregroundStyle(.white.opacity(0.35))
                     .lineLimit(1)
                     .blur(radius: blurAmount)
@@ -79,14 +82,14 @@ private struct LyricLineRow: View, Equatable {
                 if isCurrent {
                     MarqueeText(
                         text: translation,
-                        font: .system(size: 11),
+                        font: .system(size: .rem(0.6875, root: rootFontSize)),
                         color: .white.opacity(0.7),
                         loops: false,
                         lineDuration: lineDuration
                     )
                 } else {
                     Text(translation)
-                        .font(.system(size: 11))
+                        .font(.system(size: .rem(0.6875, root: rootFontSize)))
                         .foregroundStyle(.white.opacity(0.2))
                         .lineLimit(1)
                         .blur(radius: blurAmount)

--- a/Sources/Views/PlaybackControlsView.swift
+++ b/Sources/Views/PlaybackControlsView.swift
@@ -3,20 +3,21 @@ import SwiftUI
 /// Playback controls with previous, play/pause, and next buttons.
 struct PlaybackControlsView: View {
     @ObservedObject var syncEngine: PlaybackSyncEngine
+    @Environment(\.rootFontSize) private var rootFontSize
 
     var body: some View {
         HStack(spacing: 20) {
             Button { syncEngine.previousTrack() } label: {
                 Image(systemName: "backward.fill")
-                    .font(.system(size: 14))
+                    .font(.system(size: .rem(0.875, root: rootFontSize)))
             }
             Button { syncEngine.playPause() } label: {
                 Image(systemName: syncEngine.isPlaying ? "pause.fill" : "play.fill")
-                    .font(.system(size: 18))
+                    .font(.system(size: .rem(1.125, root: rootFontSize)))
             }
             Button { syncEngine.nextTrack() } label: {
                 Image(systemName: "forward.fill")
-                    .font(.system(size: 14))
+                    .font(.system(size: .rem(0.875, root: rootFontSize)))
             }
         }
         .buttonStyle(.plain)

--- a/Sources/Views/SettingsView.swift
+++ b/Sources/Views/SettingsView.swift
@@ -68,6 +68,7 @@ private struct AppearanceTab: View {
     @AppStorage("lyricsAlignment") private var lyricsAlignment = "center"
     @AppStorage("backgroundStyle") private var backgroundStyle = "solid"
     @AppStorage("solidColorHex") private var solidColorHex = "#141414"
+    @AppStorage("rootFontSize") private var rootFontSize: Double = 16
 
     private static let defaultSolidHex = "#141414"
 
@@ -106,6 +107,28 @@ private struct AppearanceTab: View {
                 }
             } header: {
                 Text(String(localized: "settings.appearance.background_section"))
+            }
+
+            Section {
+                HStack {
+                    Text(String(localized: "settings.appearance.font_size"))
+                    Spacer()
+                    Text(String(format: "%.0fpt", rootFontSize))
+                        .monospacedDigit()
+                        .foregroundStyle(.secondary)
+                }
+                Slider(value: $rootFontSize, in: 12 ... 24, step: 1)
+                if rootFontSize != 16 {
+                    HStack {
+                        Spacer()
+                        Button(String(localized: "settings.appearance.font_size_reset")) {
+                            rootFontSize = 16
+                        }
+                        .controlSize(.small)
+                    }
+                }
+            } header: {
+                Text(String(localized: "settings.appearance.font_size_section"))
             }
 
             Section {


### PR DESCRIPTION
## Summary
- 新增 CSS `rem` 风格的字体缩放机制，所有歌词相关字体大小基于可配置的根字体大小按比例缩放
- 新增 `RemScaling.swift`：定义 `EnvironmentValues.rootFontSize` 环境键和 `CGFloat.rem(_:root:)` 辅助方法
- `AppState` 新增 `rootFontSize` 属性（默认 16pt），通过 UserDefaults 持久化
- 设置窗口外观标签页新增字体大小调节滑块（12-24pt），支持一键重置
- 已迁移视图：LyricsScrollView、CompactIslandView、ExpandedIslandView、FullIslandView、PlaybackControlsView、IslandContentView（artwork column）
- OnboardingView / HelpView 保持原有固定字体大小
- 新增 en/zh-Hans/zh-Hant/ja/ko 本地化字符串

Fixes #74

## Test plan
- [ ] 打开设置窗口 → 外观标签页，确认字体大小滑块可见
- [ ] 拖动滑块调节字体大小，确认歌词显示立即响应变化
- [ ] 确认 Compact/Expanded/Full 三种模式下字体均随设置缩放
- [ ] 重启应用，确认字体大小设置已持久化
- [ ] 点击重置按钮，确认恢复为 16pt 默认值

🤖 Generated with [Claude Code](https://claude.com/claude-code)