### PR TITLE
fix(views): use MarqueeText for current line in Full mode LyricsScrollView

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Full 模式歌词加载过程中封面图片布局偏移
+- Full 模式长歌词行换行而非使用 MarqueeText 单行滚动显示
 
 ### Added
 

--- a/Sources/Views/LyricsScrollView.swift
+++ b/Sources/Views/LyricsScrollView.swift
@@ -18,7 +18,8 @@ struct LyricsScrollView: View {
                             text: line.text,
                             translation: line.translation,
                             isCurrent: line.id == currentLineIndex,
-                            distance: abs(line.id - currentLineIndex)
+                            distance: abs(line.id - currentLineIndex),
+                            lineDuration: lineDuration(for: line.id)
                         )
                         .frame(maxWidth: .infinity, alignment: alignment)
                         .environment(\.layoutDirection, line.text.isRTL ? .rightToLeft : .leftToRight)
@@ -39,6 +40,11 @@ struct LyricsScrollView: View {
             }
         }
     }
+
+    private func lineDuration(for index: Int) -> Double? {
+        guard index + 1 < lyrics.lines.count else { return nil }
+        return lyrics.lines[index + 1].time - lyrics.lines[index].time
+    }
 }
 
 /// Individual lyric line — Equatable so SwiftUI skips body evaluation
@@ -48,14 +54,26 @@ private struct LyricLineRow: View, Equatable {
     let translation: String?
     let isCurrent: Bool
     let distance: Int
+    let lineDuration: Double?
 
     var body: some View {
         VStack(spacing: 2) {
-            Text(text)
-                .font(.system(size: isCurrent ? 15 : 12, weight: isCurrent ? .bold : .regular))
-                .foregroundStyle(isCurrent ? .white : .white.opacity(0.35))
-                .blur(radius: blurAmount)
-                .scaleEffect(isCurrent ? 1.0 : 0.95)
+            if isCurrent {
+                MarqueeText(
+                    text: text,
+                    font: .system(size: 15, weight: .bold),
+                    color: .white,
+                    loops: false,
+                    lineDuration: lineDuration
+                )
+            } else {
+                Text(text)
+                    .font(.system(size: 12))
+                    .foregroundStyle(.white.opacity(0.35))
+                    .lineLimit(1)
+                    .blur(radius: blurAmount)
+                    .scaleEffect(0.95)
+            }
 
             if let translation {
                 Text(translation)


### PR DESCRIPTION
## Summary
- Full 模式当前歌词行改用 `MarqueeText` 单行滚动显示，与 Compact/Expanded 模式行为一致
- 非当前行添加 `.lineLimit(1)` 防止长文本换行
- 新增 `lineDuration` 参数传递给 `LyricLineRow`，用于计算跑马灯滚动时长

Fixes #69

## Test plan
- [x] 播放一首有较长歌词行的歌曲，进入 Full 模式
- [ ] 确认当前行长歌词以跑马灯方式单行滚动显示
- [ ] 确认非当前行长歌词被截断为单行（不换行）
- [ ] 确认短歌词行正常静态显示，无异常滚动

🤖 Generated with [Claude Code](https://claude.com/claude-code)