### PR TITLE
fix(views): use MarqueeText for translation line in Full mode

### DIFF
--- a/Sources/Views/LyricsScrollView.swift
+++ b/Sources/Views/LyricsScrollView.swift
@@ -76,9 +76,21 @@ private struct LyricLineRow: View, Equatable {
             }
 
             if let translation {
-                Text(translation)
-                    .font(.system(size: 11))
-                    .foregroundStyle(isCurrent ? .white.opacity(0.7) : .white.opacity(0.2))
+                if isCurrent {
+                    MarqueeText(
+                        text: translation,
+                        font: .system(size: 11),
+                        color: .white.opacity(0.7),
+                        loops: false,
+                        lineDuration: lineDuration
+                    )
+                } else {
+                    Text(translation)
+                        .font(.system(size: 11))
+                        .foregroundStyle(.white.opacity(0.2))
+                        .lineLimit(1)
+                        .blur(radius: blurAmount)
+                }
             }
         }
         .animation(.smooth(duration: 0.35), value: isCurrent)


### PR DESCRIPTION
## Summary
- Full 模式当前行的翻译文本改用 MarqueeText 滚动显示（补充 #78 遗漏的修改）
- 非当前行翻译添加 `.lineLimit(1)` + `.blur()` 效果

## Test plan
- [ ] 播放带翻译的长歌词歌曲，进入 Full 模式
- [ ] 确认当前行翻译以跑马灯滚动
- [ ] 确认非当前行翻译单行截断 + blur

🤖 Generated with [Claude Code](https://claude.com/claude-code)