### PR TITLE
fix(window): hide island during Mission Control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- 进入调度中心（Mission Control）时自动隐藏灵动岛，退出后恢复显示 (#84)
+
 ## 0.5.1 — 2026-04-04
 
 ### Fixed

--- a/Sources/Window/DynamicIslandPanel.swift
+++ b/Sources/Window/DynamicIslandPanel.swift
@@ -53,6 +53,7 @@ final class DynamicIslandPanel: NSPanel {
         self.contentView = container
 
         applyPosition()
+        setupMissionControlObserver()
     }
 
     // MARK: - Position Mode
@@ -240,6 +241,55 @@ final class DynamicIslandPanel: NSPanel {
                 setContentSize(correctSize)
                 positionAttachedToMenuBar()
             }
+        }
+    }
+
+    // MARK: - Mission Control Detection
+
+    private var isHiddenForMissionControl = false
+
+    private func setupMissionControlObserver() {
+        NSWorkspace.shared.notificationCenter.addObserver(
+            self,
+            selector: #selector(activeAppDidChange(_:)),
+            name: NSWorkspace.didActivateApplicationNotification,
+            object: nil
+        )
+    }
+
+    deinit {
+        NSWorkspace.shared.notificationCenter.removeObserver(self)
+    }
+
+    @objc private func activeAppDidChange(_ notification: Notification) {
+        guard let app = notification.userInfo?[NSWorkspace.applicationUserInfoKey] as? NSRunningApplication else { return }
+
+        let isDock = app.bundleIdentifier == "com.apple.dock"
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            if isDock {
+                hideForMissionControl()
+            } else if isHiddenForMissionControl {
+                showAfterMissionControl()
+            }
+        }
+    }
+
+    private func hideForMissionControl() {
+        guard !isHiddenForMissionControl, isVisible else { return }
+        isHiddenForMissionControl = true
+        NSAnimationContext.runAnimationGroup { context in
+            context.duration = 0.2
+            self.animator().alphaValue = 0
+        }
+    }
+
+    private func showAfterMissionControl() {
+        guard isHiddenForMissionControl else { return }
+        isHiddenForMissionControl = false
+        NSAnimationContext.runAnimationGroup { context in
+            context.duration = 0.2
+            self.animator().alphaValue = 1
         }
     }
 


### PR DESCRIPTION
## Summary
- 监听 `NSWorkspace.didActivateApplicationNotification`，当 Dock 成为活跃应用（Mission Control / Launchpad）时，通过 `alphaValue` 动画淡出灵动岛
- 其他应用激活时自动恢复显示，0.2s 平滑过渡无闪烁
- 附加模式和自由浮动模式均生效

Fixes #81

## Test plan
- [ ] 吸附模式下按 F3 进入调度中心，灵动岛应平滑淡出
- [ ] 退出调度中心后灵动岛应平滑恢复
- [ ] 自由浮动模式下同样验证
- [ ] 打开 Launchpad 时灵动岛应隐藏
- [ ] 用户手动隐藏灵动岛后进出调度中心不会导致面板意外恢复

🤖 Generated with [Claude Code](https://claude.com/claude-code)